### PR TITLE
Rename choria.use_srv_records -> choria.use_srv

### DIFF
--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -12,7 +12,7 @@ factsource = yaml
 plugin.yaml = <%= instance_home %>/etc/facts.yaml
 
 plugin.choria.ssldir = <%= COLLECTIVE_SSL %>
-plugin.choria.use_srv_records = false
+plugin.choria.use_srv = false
 plugin.choria.middleware_hosts = 127.0.0.1:14222,127.0.0.1:14223,127.0.0.1:14224
 plugin.choria.federation_middleware_hosts = 127.0.0.1:14225
 plugin.choria.randomize_middleware_hosts = true

--- a/templates/federation.cfg.erb
+++ b/templates/federation.cfg.erb
@@ -12,7 +12,7 @@ factsource = yaml
 plugin.yaml = <%= instance_home %>/etc/facts.yaml
 
 plugin.choria.ssldir = <%= COLLECTIVE_SSL %>
-plugin.choria.use_srv_records = false
+plugin.choria.use_srv = false
 plugin.choria.middleware_hosts = 127.0.0.1:14222,127.0.0.1:14223,127.0.0.1:14224
 plugin.choria.federation_middleware_hosts = 127.0.0.1:14225
 plugin.choria.randomize_middleware_hosts = true

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -14,7 +14,7 @@ factsource = yaml
 plugin.yaml = <%= instance_home %>/etc/facts.yaml
 
 plugin.choria.ssldir = <%= COLLECTIVE_SSL %>
-plugin.choria.use_srv_records = false
+plugin.choria.use_srv = false
 plugin.choria.middleware_hosts = 127.0.0.1:14222,127.0.0.1:14223,127.0.0.1:14224
 plugin.choria.security.certname_whitelist = /\.choria$/
 plugin.choria.randomize_middleware_hosts = true


### PR DESCRIPTION
Choria use `choria.use_srv` to check SRV records while MCollective used
`choria.use_srv_records` for this purpose.  We are updating the mcorpc
support gem to use a single setting `choria.use_srv` so update this
repository accordingly.